### PR TITLE
Fix missing root prefix in discriminator encoders

### DIFF
--- a/birdie_snapshots/codegen_discriminator_as_elements_test.accepted
+++ b/birdie_snapshots/codegen_discriminator_as_elements_test.accepted
@@ -65,34 +65,34 @@ pub type DataElement {
   )
 }
 
-pub fn data_decoder() -> decode.Decoder(List(Data)) {
+pub fn data_decoder() -> decode.Decoder(List(DataElement)) {
   decode.list(decode.at(["kind"], decode.string)
   |> decode.then(fn(tag) {
     case tag {
     "up" -> decode.into({
     use height <- decode.parameter
-    DataUp(height:)
+    DataElementUp(height:)
   })
   |> decode.field("height", decode.int)
     "down" -> decode.into({
     use depth <- decode.parameter
     use note <- decode.parameter
-    DataDown(depth:, note:)
+    DataElementDown(depth:, note:)
   })
   |> decode.field("depth", decode.float)
   |> decode.field("note", decode.nullable(decode.string))
-      _ -> decode.fail("Data")
+      _ -> decode.fail("DataElement")
     }
   }))
 }
 
-pub fn data_to_json(data: List(Data)) -> json.Json {
+pub fn data_to_json(data: List(DataElement)) -> json.Json {
   json.array(data, fn(data) { case data {
-    DataUp(height:) -> json.object([
+    DataElementUp(height:) -> json.object([
     #("kind", json.string("up")),
     #("height", json.int(height)),
   ])
-    DataDown(depth:, note:) -> json.object([
+    DataElementDown(depth:, note:) -> json.object([
     #("kind", json.string("down")),
     #("depth", json.float(depth)),
     #("note", json.nullable(note, json.string)),

--- a/birdie_snapshots/codegen_discriminator_as_elements_test.accepted
+++ b/birdie_snapshots/codegen_discriminator_as_elements_test.accepted
@@ -88,11 +88,11 @@ pub fn data_decoder() -> decode.Decoder(List(Data)) {
 
 pub fn data_to_json(data: List(Data)) -> json.Json {
   json.array(data, fn(data) { case data {
-    Up(height:) -> json.object([
+    DataUp(height:) -> json.object([
     #("kind", json.string("up")),
     #("height", json.int(height)),
   ])
-    Down(depth:, note:) -> json.object([
+    DataDown(depth:, note:) -> json.object([
     #("kind", json.string("down")),
     #("depth", json.float(depth)),
     #("note", json.nullable(note, json.string)),

--- a/birdie_snapshots/codegen_discriminator_nullable_as_elements_test.accepted
+++ b/birdie_snapshots/codegen_discriminator_nullable_as_elements_test.accepted
@@ -89,11 +89,11 @@ pub fn data_decoder() -> decode.Decoder(List(option.Option(Data))) {
 pub fn data_to_json(data: List(option.Option(Data))) -> json.Json {
   json.array(data, fn(data) { case data {
     option.Some(data) -> case data {
-    Up(height:) -> json.object([
+    DataUp(height:) -> json.object([
     #("kind", json.string("up")),
     #("height", json.int(height)),
   ])
-    Down(depth:, note:) -> json.object([
+    DataDown(depth:, note:) -> json.object([
     #("kind", json.string("down")),
     #("depth", json.float(depth)),
     #("note", json.nullable(note, json.string)),

--- a/birdie_snapshots/codegen_discriminator_nullable_as_elements_test.accepted
+++ b/birdie_snapshots/codegen_discriminator_nullable_as_elements_test.accepted
@@ -65,35 +65,35 @@ pub type DataElement {
   )
 }
 
-pub fn data_decoder() -> decode.Decoder(List(option.Option(Data))) {
+pub fn data_decoder() -> decode.Decoder(List(option.Option(DataElement))) {
   decode.list(decode.at(["kind"], decode.string)
   |> decode.then(fn(tag) {
     case tag {
     "up" -> decode.into({
     use height <- decode.parameter
-    DataUp(height:)
+    DataElementUp(height:)
   })
   |> decode.field("height", decode.int)
     "down" -> decode.into({
     use depth <- decode.parameter
     use note <- decode.parameter
-    DataDown(depth:, note:)
+    DataElementDown(depth:, note:)
   })
   |> decode.field("depth", decode.float)
   |> decode.field("note", decode.nullable(decode.string))
-      _ -> decode.fail("Data")
+      _ -> decode.fail("DataElement")
     }
   }))
 }
 
-pub fn data_to_json(data: List(option.Option(Data))) -> json.Json {
+pub fn data_to_json(data: List(option.Option(DataElement))) -> json.Json {
   json.array(data, fn(data) { case data {
     option.Some(data) -> case data {
-    DataUp(height:) -> json.object([
+    DataElementUp(height:) -> json.object([
     #("kind", json.string("up")),
     #("height", json.int(height)),
   ])
-    DataDown(depth:, note:) -> json.object([
+    DataElementDown(depth:, note:) -> json.object([
     #("kind", json.string("down")),
     #("depth", json.float(depth)),
     #("note", json.nullable(note, json.string)),

--- a/birdie_snapshots/codegen_discriminator_nullable_test.accepted
+++ b/birdie_snapshots/codegen_discriminator_nullable_test.accepted
@@ -85,11 +85,11 @@ pub fn data_decoder() -> decode.Decoder(option.Option(Data)) {
 pub fn data_to_json(data: option.Option(Data)) -> json.Json {
   case data {
     option.Some(data) -> case data {
-    Up(height:) -> json.object([
+    DataUp(height:) -> json.object([
     #("kind", json.string("up")),
     #("height", json.int(height)),
   ])
-    Down(depth:, note:) -> json.object([
+    DataDown(depth:, note:) -> json.object([
     #("kind", json.string("down")),
     #("depth", json.float(depth)),
     #("note", json.nullable(note, json.string)),

--- a/birdie_snapshots/codegen_discriminator_test.accepted
+++ b/birdie_snapshots/codegen_discriminator_test.accepted
@@ -84,11 +84,11 @@ pub fn data_decoder() -> decode.Decoder(Data) {
 
 pub fn data_to_json(data: Data) -> json.Json {
   case data {
-    Up(height:) -> json.object([
+    DataUp(height:) -> json.object([
     #("kind", json.string("up")),
     #("height", json.int(height)),
   ])
-    Down(depth:, note:) -> json.object([
+    DataDown(depth:, note:) -> json.object([
     #("kind", json.string("down")),
     #("depth", json.float(depth)),
     #("note", json.nullable(note, json.string)),

--- a/birdie_snapshots/codegen_element_enum_directions_nullable_test.accepted
+++ b/birdie_snapshots/codegen_element_enum_directions_nullable_test.accepted
@@ -30,19 +30,19 @@ pub type DataElement {
   Right
 }
 
-pub fn data_decoder() -> decode.Decoder(List(option.Option(Data))) {
+pub fn data_decoder() -> decode.Decoder(List(option.Option(DataElement))) {
   decode.list(decode.nullable(decode.then(decode.string, fn(s) {
     case s {
       "UP" -> decode.into(Up)
       "DOWN" -> decode.into(Down)
       "LEFT" -> decode.into(Left)
       "RIGHT" -> decode.into(Right)
-      _ -> decode.fail(Data)
+      _ -> decode.fail(DataElement)
     }
   })))
 }
 
-pub fn data_to_json(data: List(option.Option(Data))) -> json.Json {
+pub fn data_to_json(data: List(option.Option(DataElement))) -> json.Json {
   json.array(data, json.nullable(_, fn(data) { json.string(case data {
     Up -> "UP"
     Down -> "DOWN"

--- a/birdie_snapshots/codegen_element_enum_directions_test.accepted
+++ b/birdie_snapshots/codegen_element_enum_directions_test.accepted
@@ -29,19 +29,19 @@ pub type DataElement {
   Right
 }
 
-pub fn data_decoder() -> decode.Decoder(List(Data)) {
+pub fn data_decoder() -> decode.Decoder(List(DataElement)) {
   decode.list(decode.then(decode.string, fn(s) {
     case s {
       "UP" -> decode.into(Up)
       "DOWN" -> decode.into(Down)
       "LEFT" -> decode.into(Left)
       "RIGHT" -> decode.into(Right)
-      _ -> decode.fail(Data)
+      _ -> decode.fail(DataElement)
     }
   }))
 }
 
-pub fn data_to_json(data: List(Data)) -> json.Json {
+pub fn data_to_json(data: List(DataElement)) -> json.Json {
   json.array(data, fn(data) { json.string(case data {
     Up -> "UP"
     Down -> "DOWN"

--- a/birdie_snapshots/codegen_properties_in_elements_test.accepted
+++ b/birdie_snapshots/codegen_properties_in_elements_test.accepted
@@ -37,15 +37,15 @@ pub type DataElement {
   )
 }
 
-pub fn data_decoder() -> decode.Decoder(List(Data)) {
+pub fn data_decoder() -> decode.Decoder(List(DataElement)) {
   decode.list(decode.into({
     use count <- decode.parameter
-    Data(count:)
+    DataElement(count:)
   })
   |> decode.field("count", decode.int))
 }
 
-pub fn data_to_json(data: List(Data)) -> json.Json {
+pub fn data_to_json(data: List(DataElement)) -> json.Json {
   json.array(data, fn(data) { json.object([
     #("count", json.int(data.count)),
   ]) })

--- a/birdie_snapshots/codegen_properties_nested_test.accepted
+++ b/birdie_snapshots/codegen_properties_nested_test.accepted
@@ -59,8 +59,8 @@ pub type Data {
   )
 }
 
-pub type Datavalues {
-  Datavalues(
+pub type DataValues {
+  DataValues(
     amount: Int,
     key: String,
   )

--- a/birdie_snapshots/codegen_properties_nullable_in_elements_test.accepted
+++ b/birdie_snapshots/codegen_properties_nullable_in_elements_test.accepted
@@ -38,15 +38,15 @@ pub type DataElement {
   )
 }
 
-pub fn data_decoder() -> decode.Decoder(List(option.Option(Data))) {
+pub fn data_decoder() -> decode.Decoder(List(option.Option(DataElement))) {
   decode.list(decode.nullable(decode.into({
     use count <- decode.parameter
-    Data(count:)
+    DataElement(count:)
   })
   |> decode.field("count", decode.int)))
 }
 
-pub fn data_to_json(data: List(option.Option(Data))) -> json.Json {
+pub fn data_to_json(data: List(option.Option(DataElement))) -> json.Json {
   json.array(data, fn(data) { case data {
     option.Some(data) -> json.object([
     #("count", json.int(data.count)),

--- a/birdie_snapshots/codegen_root_name_test.accepted
+++ b/birdie_snapshots/codegen_root_name_test.accepted
@@ -30,19 +30,19 @@ pub type DirectionElement {
   Right
 }
 
-pub fn direction_decoder() -> decode.Decoder(List(option.Option(Direction))) {
+pub fn direction_decoder() -> decode.Decoder(List(option.Option(DirectionElement))) {
   decode.list(decode.nullable(decode.then(decode.string, fn(s) {
     case s {
       "UP" -> decode.into(Up)
       "DOWN" -> decode.into(Down)
       "LEFT" -> decode.into(Left)
       "RIGHT" -> decode.into(Right)
-      _ -> decode.fail(Direction)
+      _ -> decode.fail(DirectionElement)
     }
   })))
 }
 
-pub fn direction_to_json(data: List(option.Option(Direction))) -> json.Json {
+pub fn direction_to_json(data: List(option.Option(DirectionElement))) -> json.Json {
   json.array(data, json.nullable(_, fn(data) { json.string(case data {
     Up -> "UP"
     Down -> "DOWN"

--- a/src/json_typedef.gleam
+++ b/src/json_typedef.gleam
@@ -1049,7 +1049,7 @@ fn en_discriminator(
 
   let clauses =
     list.map(properties, fn(pair) {
-      let name = justin.pascal_case(pair.0)
+      let name = name <> justin.pascal_case(pair.0)
       let args = case pair.2 {
         [] -> ""
         a -> "(" <> string.join(a, ":, ") <> ":)"

--- a/src/json_typedef.gleam
+++ b/src/json_typedef.gleam
@@ -599,7 +599,8 @@ fn type_name(schema: Schema, name: String) -> String {
     Ref(name:, ..) -> name
 
     Values(schema:, ..) -> "dict.Dict(" <> type_name(schema, name) <> ")"
-    Elements(schema:, ..) -> "List(" <> type_name(schema, name) <> ")"
+    Elements(schema:, ..) ->
+      "List(" <> type_name(schema, name <> "Element") <> ")"
     Empty -> "dynamic.Dynamic"
 
     Type(type_:, ..) ->
@@ -905,7 +906,7 @@ fn en_schema(
     Discriminator(nullable:, metadata: _, mapping:, tag:) ->
       en_discriminator(mapping, tag, nullable, data, name)
     Elements(schema:, nullable:, metadata: _) ->
-      en_elements(schema, nullable, data, name)
+      en_elements(schema, nullable, data, name <> "Element")
     Empty -> Error(CannotConvertEmptyToJsonError)
     Enum(nullable:, variants:, metadata: _) ->
       en_enum(variants, nullable, data, name)
@@ -968,7 +969,7 @@ fn de_schema(schema: Schema, name: String) -> Result(Out, CodegenError) {
     Discriminator(nullable:, metadata: _, mapping:, tag:) ->
       de_discriminator(mapping, tag, nullable, name)
     Elements(schema:, nullable:, metadata: _) ->
-      de_elements(schema, nullable, name)
+      de_elements(schema, nullable, name <> "Element")
     Empty -> Ok(Out("decode.dynamic", "dynamic.Dynamic"))
     Enum(nullable:, variants:, metadata: _) -> de_enum(variants, nullable, name)
     Properties(nullable:, schema:, metadata: _) ->

--- a/src/json_typedef.gleam
+++ b/src/json_typedef.gleam
@@ -697,14 +697,14 @@ fn type_variant(
 
   use gen <- result.try(
     list.try_fold(properties, gen, fn(gen, prop) {
-      gen_type(gen, name <> prop.0, prop.1)
+      gen_type(gen, name <> justin.pascal_case(prop.0), prop.1)
     }),
   )
 
   use gen <- result.try(
     list.try_fold(optional_properties, gen, fn(gen, prop) {
       let gen = Generator(..gen, option_used: True)
-      gen_type(gen, name <> prop.0, prop.1)
+      gen_type(gen, name <> justin.pascal_case(prop.0), prop.1)
     }),
   )
 
@@ -1028,7 +1028,7 @@ fn en_discriminator(
 ) -> Result(Out, CodegenError) {
   use properties <- result.try(
     list.try_map(mapping, fn(pair) {
-      let name = name <> justin.pascal_case(name)
+      let name = name <> justin.pascal_case(pair.0)
       let result =
         en_properties_schema(
           pair.1,


### PR DESCRIPTION
I was trying to use the library, but noticed that the encoders generated for discriminators were missing the prefix used in the type. So here is a little quickfix :)